### PR TITLE
MDict: support image and sound

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,11 @@ Very simple dictionary search application supporting;
 - EPWING ebz compression (.ebz) 
 - LingvoDSL (.dsl)
 - LingvoDSL dz compression (.dsl.dz)
-- MDict(*1)  (.mdx)
+- MDict  (.mdx, .mdd)
 - StarDict (.ifo .dict)
 - StarDict (.dict.dz)
 - PDIC/Unicode (PDIC format v6.00, 6.10) (.DIC)
 
-(*1) MDict support is _Experimental_ status that supports text only
- 
   ![Application image](https://raw.githubusercontent.com/eb4j/ebviewer/main/docs/img/screen_image.png)
 
 ## Install

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,7 +94,7 @@ dependencies {
     implementation("com.github.takawitter:trie4j:0.9.8")
 
     // for mdict
-    implementation("io.github.eb4j:mdict4j:0.1.4")
+    implementation("io.github.eb4j:mdict4j:0.2.0")
     implementation("org.jsoup:jsoup:1.14.3")
 
     // for video replay

--- a/src/main/java/io/github/eb4j/ebview/dictionary/DictionariesManager.java
+++ b/src/main/java/io/github/eb4j/ebview/dictionary/DictionariesManager.java
@@ -69,7 +69,8 @@ public class DictionariesManager {
         for (File f : listFiles) {
             try {
                 loadDictionary(f);
-            } catch (Exception ignore) {
+            } catch (Exception e) {
+                LOG.warn("get exception when loading", e);
             }
         }
     }

--- a/src/main/java/io/github/eb4j/ebview/dictionary/MDict.java
+++ b/src/main/java/io/github/eb4j/ebview/dictionary/MDict.java
@@ -1,7 +1,7 @@
 package io.github.eb4j.ebview.dictionary;
 
 import io.github.eb4j.ebview.data.IDictionary;
-import io.github.eb4j.ebview.dictionary.mdict.MDX;
+import io.github.eb4j.ebview.dictionary.mdict.MDictDictionaryImpl;
 import io.github.eb4j.mdict.MDException;
 
 import java.io.File;
@@ -32,7 +32,7 @@ public class MDict implements IDictionaryFactory {
     @Override
     public Set<IDictionary> loadDict(File file) throws MDException, IOException {
         Set<IDictionary> result = new HashSet<>();
-        result.add(new MDX(file));
+        result.add(new MDictDictionaryImpl(file));
         return result;
     }
 }

--- a/src/main/java/io/github/eb4j/ebview/dictionary/MDict.java
+++ b/src/main/java/io/github/eb4j/ebview/dictionary/MDict.java
@@ -19,7 +19,7 @@ public class MDict implements IDictionaryFactory {
      * @return Whether or not the file is supported
      */
     @Override
-    public boolean isSupportedFile(File file) {
+    public boolean isSupportedFile(final File file) {
         return file.getPath().endsWith(".MDX") || file.getPath().endsWith(".mdx");
     }
 
@@ -30,7 +30,7 @@ public class MDict implements IDictionaryFactory {
      * @return An IDictionary file that can read articles from the file
      */
     @Override
-    public Set<IDictionary> loadDict(File file) throws MDException, IOException {
+    public Set<IDictionary> loadDict(final File file) throws MDException, IOException {
         Set<IDictionary> result = new HashSet<>();
         result.add(new MDictDictionaryImpl(file));
         return result;

--- a/src/main/java/io/github/eb4j/ebview/dictionary/mdict/MDX.java
+++ b/src/main/java/io/github/eb4j/ebview/dictionary/mdict/MDX.java
@@ -2,12 +2,17 @@ package io.github.eb4j.ebview.dictionary.mdict;
 
 import io.github.eb4j.ebview.data.DictionaryEntry;
 import io.github.eb4j.ebview.data.IDictionary;
+import io.github.eb4j.ebview.utils.ImageUtils;
 import io.github.eb4j.mdict.MDException;
 import io.github.eb4j.mdict.MDictDictionary;
 import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.jsoup.safety.Safelist;
+import org.jsoup.select.Elements;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,11 +20,17 @@ import java.util.Map;
 
 public class MDX implements IDictionary {
 
-    private MDictDictionary mdictionary;
+    private final MDictDictionary mdictionary;
+    private final MDictDictionary mData;
 
     public MDX(final File mdxFile) throws MDException, IOException {
         String mdxPath = mdxFile.getPath();
         mdictionary = MDictDictionary.loadDicitonary(mdxPath);
+        if (mdictionary.getMdxVersion().equals("2.0")) {
+            mData = MDictDictionary.loadDictionaryData(mdxPath);
+        } else {
+            mData = null;
+        }
     }
 
     @Override
@@ -63,11 +74,13 @@ public class MDX implements IDictionary {
     private void addEntry(final List<DictionaryEntry> result, final Map.Entry<String, Object> entry) throws MDException {
         if (entry.getValue() instanceof Long) {
             result.add(new DictionaryEntry(entry.getKey(),
-                    cleaHtmlArticle(mdictionary.getText((Long) entry.getValue())), getDictionaryName()));
+                    retrieveDataAndUpdateLink(cleaHtmlArticle(mdictionary.getText((Long) entry.getValue()))),
+                    getDictionaryName()));
         } else {
             Long[] values = (Long[]) entry.getValue();
             for (int i = 0; i < values.length; i++) {
-                result.add(new DictionaryEntry(entry.getKey(), cleaHtmlArticle(mdictionary.getText(values[i])),
+                result.add(new DictionaryEntry(entry.getKey(),
+                        retrieveDataAndUpdateLink(cleaHtmlArticle(mdictionary.getText(values[i]))),
                         getDictionaryName()));
             }
         }
@@ -77,7 +90,65 @@ public class MDX implements IDictionary {
         Safelist whitelist = new Safelist();
         whitelist.addTags("b", "br");
         whitelist.addAttributes("font", "color", "face");
+        whitelist.addAttributes("img", "src");
+        whitelist.addAttributes("a", "href");
         return Jsoup.clean(mdictHtmlText, whitelist);
     }
+
+    private String retrieveDataAndUpdateLink(final String mdictHtmlText) {
+        Document document = Jsoup.parse(mdictHtmlText);
+        // Support embeded image
+        try {
+            Elements elements = document.select("img[src]");
+            for (Element element: elements) {
+                String linkUrl = element.attr("src");
+                if (linkUrl.startsWith("file://pic/")) {
+                    String targetKey = linkUrl.substring(6);
+                    byte[] rawData = getRawData(targetKey);
+                    StringBuffer stringBuffer = new StringBuffer();
+                    stringBuffer.append("data:image/png;base64,");
+                    stringBuffer.append(ImageUtils.convertImage2Base64("png", rawData));
+                    element.attr("src", stringBuffer.toString());
+                }
+            }
+        } catch (MDException | IOException e) {
+            e.printStackTrace();
+        }
+        // Support sound
+        try {
+            Elements elements = document.select("a[href]");
+            for (Element element: elements) {
+                String linkUrl = element.attr("href");
+                if (linkUrl.startsWith("sound://audio/")) {
+                    String targetKey = linkUrl.substring(7);
+                    byte[] rawData = getRawData(targetKey);
+                    File tmpAudioFile = File.createTempFile("ebviewer", ".mp3");
+                    tmpAudioFile.deleteOnExit();
+                    try (FileOutputStream outputStream = new FileOutputStream(tmpAudioFile)) {
+                        outputStream.write(rawData);
+                    }
+                    element.attr("href", "file://" + tmpAudioFile.toPath());
+                }
+            }
+        } catch (IOException | MDException e) {
+            e.printStackTrace();
+        }
+        return document.outerHtml();
+    }
+
+    private byte[] getRawData(final String targetKey) throws MDException {
+        byte[] result = null;
+        for (Map.Entry<String, Object> entry: mData.getEntries(targetKey)) {
+            if (entry.getKey().equals(targetKey)) {
+               Object value = entry.getValue();
+               if (value instanceof Long) {
+                   result = mData.getData((Long) value);
+                   break;
+               }
+            }
+        }
+        return result;
+    }
+
 
 }

--- a/src/main/java/io/github/eb4j/ebview/dictionary/mdict/MDictDictionaryImpl.java
+++ b/src/main/java/io/github/eb4j/ebview/dictionary/mdict/MDictDictionaryImpl.java
@@ -63,7 +63,7 @@ public class MDictDictionaryImpl implements IDictionary {
      * @return List of entries. May be empty, but cannot be null.
      */
     @Override
-    public List<DictionaryEntry> readArticlesPredictive(String word) throws Exception {
+    public List<DictionaryEntry> readArticlesPredictive(final String word) throws Exception {
         List<DictionaryEntry> result = new ArrayList<>();
         for (Map.Entry<String, Object> entry: mdictionary.getEntriesPredictive(word)) {
             addEntry(result, entry);
@@ -71,7 +71,8 @@ public class MDictDictionaryImpl implements IDictionary {
         return result;
     }
 
-    private void addEntry(final List<DictionaryEntry> result, final Map.Entry<String, Object> entry) throws MDException {
+    private void addEntry(final List<DictionaryEntry> result, final Map.Entry<String, Object> entry)
+            throws MDException {
         if (entry.getValue() instanceof Long) {
             result.add(new DictionaryEntry(entry.getKey(),
                     retrieveDataAndUpdateLink(cleaHtmlArticle(mdictionary.getText((Long) entry.getValue()))),

--- a/src/main/java/io/github/eb4j/ebview/dictionary/mdict/MDictDictionaryImpl.java
+++ b/src/main/java/io/github/eb4j/ebview/dictionary/mdict/MDictDictionaryImpl.java
@@ -18,12 +18,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class MDX implements IDictionary {
+public class MDictDictionaryImpl implements IDictionary {
 
     private final MDictDictionary mdictionary;
     private final MDictDictionary mData;
 
-    public MDX(final File mdxFile) throws MDException, IOException {
+    public MDictDictionaryImpl(final File mdxFile) throws MDException, IOException {
         String mdxPath = mdxFile.getPath();
         mdictionary = MDictDictionary.loadDicitonary(mdxPath);
         if (mdictionary.getMdxVersion().equals("2.0")) {
@@ -149,6 +149,4 @@ public class MDX implements IDictionary {
         }
         return result;
     }
-
-
 }

--- a/src/main/java/io/github/eb4j/ebview/gui/LinkActionListener.java
+++ b/src/main/java/io/github/eb4j/ebview/gui/LinkActionListener.java
@@ -1,6 +1,7 @@
 package io.github.eb4j.ebview.gui;
 
 import io.github.eb4j.ebview.gui.dialogs.MoviePlay;
+import uk.co.caprica.vlcj.player.component.AudioPlayerComponent;
 
 import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.AudioSystem;
@@ -17,6 +18,8 @@ import java.util.Arrays;
 public class LinkActionListener implements HyperlinkListener {
 
     private static final String[] MOVIE_EXTS = {".mpg", ".MPG", ".ogv", ".mp4", ".mov"};
+    private static final String[] SOUND_EXTS = {".wav", ".WAV"};
+    private static final String[] MUSIC_EXTS = {".mp3", ".MP3"};
 
     private static boolean hasExt(final String path, final String[] extrn) {
         return Arrays.stream(extrn).anyMatch(entry -> path.endsWith(entry));
@@ -55,11 +58,14 @@ public class LinkActionListener implements HyperlinkListener {
             if (url.getProtocol().equals("file")) {
                 try {
                     String path = url.getPath();
-                    if (path.endsWith(".wav") || path.endsWith(".WAV")) {
+                    if (hasExt(path, SOUND_EXTS)) {
                         playSound(new File(url.toURI()));
                     } else if (hasExt(path, MOVIE_EXTS)) {
                         MoviePlay player = new MoviePlay(354, 280);
                         player.play(path);
+                    } else if (hasExt(path, MUSIC_EXTS)) {
+                        AudioPlayerComponent audioPlayerComponent = new AudioPlayerComponent();
+                        audioPlayerComponent.mediaPlayer().media().play(path);
                     }
                 } catch (URISyntaxException e) {
                     e.printStackTrace();


### PR DESCRIPTION
This PR add a support for images and sounds of MDict dictionary stored in MDD file.

- Bump mdict4j@0.2.0
- Support inline image
- Support mp3 audio file play
